### PR TITLE
修复:伤害来源非玩家时(如宠物)MM怪物不会掉落SX物品

### DIFF
--- a/src/main/java/github/saukiya/sxitem/util/Config.java
+++ b/src/main/java/github/saukiya/sxitem/util/Config.java
@@ -22,6 +22,7 @@ public class Config {
     public static final String PROTECT_NBT = "ProtectNBT";
     public static final String GIVE_OVERFLOW_DROP = "GiveOverflowDrop";
     public static final String MOB_DROP_TO_PLAYER_INVENTORY = "MobDropToPlayerInventory";
+    public static final String MOB_DROP_IF_NON_PLAYER_KILLED = "MobDropIfNonPlayerKilled";
 
     @Getter
     private static YamlConfiguration config;

--- a/src/main/resources/Config.yml
+++ b/src/main/resources/Config.yml
@@ -13,3 +13,5 @@ ProtectNBT:
 GiveOverflowDrop: true
 #史诗怪物掉落的SX物品直接进入玩家背包
 MobDropToPlayerInventory: true
+#史诗怪物在不被玩家击杀时是否掉落物品
+MobDropIfNonPlayerKilled: false

--- a/src/main/resources/Config_en.yml
+++ b/src/main/resources/Config_en.yml
@@ -11,3 +11,5 @@ ProtectNBT:
 GiveOverflowDrop: true
 # SX-Items dropped by epic monsters go directly into player's inventory
 MobDropToPlayerInventory: true
+# Should epic monsters drop SX-Items when not killed by a player?
+MobDropIfNonPlayerKilled: false

--- a/src/main/resources/Config_zh.yml
+++ b/src/main/resources/Config_zh.yml
@@ -13,3 +13,5 @@ ProtectNBT:
 GiveOverflowDrop: true
 #史诗怪物掉落的SX物品直接进入玩家背包
 MobDropToPlayerInventory: true
+#史诗怪物在不被玩家击杀时是否掉落物品
+MobDropIfNonPlayerKilled: false


### PR DESCRIPTION
在我调服务器的宠物插件时，发现玩家的宠物打死MM的怪不会掉落物品
查看源码发现 https://github.com/Saukiya/SX-Item/blob/1752f4f000d43a7a44dc69f0233a7426c615040c/src/main/java/github/saukiya/sxitem/helper/MythicMobsHelper.java#L222-L234
https://github.com/Saukiya/SX-Item/blob/1752f4f000d43a7a44dc69f0233a7426c615040c/src/main/java/github/saukiya/sxitem/helper/MythicMobsHelper.java#L179-L191
这里判断了死亡伤害是否来自玩家，忽略了其他死亡情况
例如宠物插件等一些插件不会将伤害来源设置为玩家，这种情况下会导致掉落物丢失
所以加了个开关，用来控制这样的情况下掉落物是否生成